### PR TITLE
Reset last_event exactly on a drop or fall.

### DIFF
--- a/game.py
+++ b/game.py
@@ -47,6 +47,7 @@ class Game(object):
         elif ((self.block.can_move(self, DOWN)) and (time.time() - self.last_drop > self.level.fall_speed)):
             self.block.move(DOWN)
             self.last_drop = time.time()
+            self.last_event = time.time()
     def update_state(self):
         def remove_lines():
             def is_full(line):

--- a/window.py
+++ b/window.py
@@ -265,7 +265,7 @@ class Window(object):
                 elif (event.key == pygame.K_DOWN):
                     if self.game.block.can_move(self.game, DOWN):
                         self.game.block.move(DOWN)
-                self.game.last_event = time.time()
+                        self.game.last_event = time.time()
                 break
 
         # Continuous key presses


### PR DESCRIPTION
The check for last event is used in two places. Firstly to check when we should repeat a soft drop if DOWN is held. Secondly to check when the block should stop being slidable and stick to the floor. In both cases, the exact condition should be changed to be that the block either fell itself or was dropped (either hard or soft). Currently the timer resets each time a key is pressed.

The soft drop should repeat if it has been enough time since the previous soft drop. Moving the block to the left or right (which can be done while DOWN is held) should not affect how fast the soft drops repeat. Therefore the time should not be reset on LEFT, RIGHT, ROTATE, etc. Resetting the timer on falls just means that the block will not occasionally "double drop" when a fall and a soft drop coincide. Resetting the timer on hard drops has no effect since after a hard drop there is no longer a possibility to soft drop.

When a block hits the floor, it is possible that it hasnt been actively moved for a while, but has been left to fall, with the player getting ready to "slide" it as soon as it hits the floor. If we do not reset the "last_event" timer for falls, then the block could instantly stick, because it has already been enough time since the last player action. Resetting the timer every time the block falls on its own avoids this. On the other hand, resetting the timer for each left or right movement means that a player can slide the block for an indefinite amount of time after it hits the floor, as long as they press the movement keys frequently enough, since each movement will reset the timer. For the same reason, DOWN presses should not reset the time unless they lead to an actual downward movement. These changes mean that the sliding time starts exactly when the block hits the floor.
